### PR TITLE
Fix configuration indentation and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,100 @@
-
-
-
-
-
-
 ---
-
 
 ## README.md (drop into repo root)
 ```md
-# MinuteOne (M1) — Offline‑first bedside side‑panel (MVP)
+# MinuteOne (M1) — Offline-first bedside side-panel (MVP)
 
-
-**Goal:** Save clinicians **≥5–10 minutes/encounter** and reduce handoff omissions by turning a bedside conversation into a **SOAP/MDM note**, **I‑PASS handoff**, and **bilingual discharge**, with **rule‑based plan suggestions**. **Deterministic‑first**, offline‑by‑default. A tiny local LLM (≈3B, 4‑bit) is used **only** to fill ambiguous JSON slots.
-
+**Goal:** Save clinicians **≥5–10 minutes/encounter** and reduce handoff omissions by turning a bedside conversation into a **SOAP/MDM note**, **I-PASS handoff**, and **bilingual discharge**, with **rule-based plan suggestions**. **Deterministic-first**, offline-by-default. A tiny local LLM (≈3B, 4-bit) is used **only** to fill ambiguous JSON slots.
 
 ---
-
 
 ## ✨ Features (MVP)
-- **ASR service**: faster‑whisper *small‑int8* + VAD; timestamped segments; lightweight diarization heuristic.
+- **ASR service**: faster-whisper *small-int8* + VAD; timestamped segments; lightweight diarization heuristic.
 - **Extractor**: regex/rules for doses, frequencies, durations, negations; ontology maps (ASA→aspirin, “trops”→troponin). Tiny LLM fills **VisitJSON** strictly.
 - **Chart cache + Evidence**: SQLite FHIR subset; builds **EvidenceChips** with deltas.
-- **Composers**: Jinja2 templates for **Note (SOAP/MDM)**, **I‑PASS**, **Discharge** (EN + ES), each with citations.
-- **Chips engine**: confidence score + bands A/B/C/D; batch‑accept hook.
-- **Side‑panel UI**: PyQt tabs (**Note | Handoff | Discharge | Sources**), transcript pane, chips rail, keyboard‑first.
+- **Composers**: Jinja2 templates for **Note (SOAP/MDM)**, **I-PASS**, **Discharge** (EN + ES), each with citations.
+- **Chips engine**: confidence score + bands A/B/C/D; batch-accept hook.
+- **Side-panel UI**: PyQt tabs (**Note | Handoff | Discharge | Sources**), transcript pane, chips rail, keyboard-first.
 - **Audit & metrics**: local JSONL; session timers/keystrokes (stubs present).
 
-
 ---
-
 
 ## 🧱 Architecture
-- **Backend**: FastAPI (local‑only), Pydantic v2 schemas, Jinja2 composers, SQLite (FTS5).
-- **Models**: faster‑whisper small‑int8, Llama‑3.2‑3B‑Instruct Q4_K_S (llama.cpp).
-- **UI**: PyQt side‑panel; chips rail; keyboard‑first controls.
-
+- **Backend**: FastAPI (local-only), Pydantic v2 schemas, Jinja2 composers, SQLite (FTS5).
+- **Models**: faster-whisper small-int8, Llama-3.2-3B-Instruct Q4_K_S (llama.cpp).
+- **UI**: PyQt side-panel; chips rail; keyboard-first controls.
 
 ---
-
 
 ## ⚙️ Requirements
 - **OS**: Windows 10/11 (tested). macOS workable with minor tweaks.
-- **Hardware**: Core i7‑1165G7 (16GB RAM, SSD). Optional GeForce MX350 (≈2GB VRAM) for `n_gpu_layers`.
+- **Hardware**: Core i7-1165G7 (16GB RAM, SSD). Optional GeForce MX350 (≈2GB VRAM) for `n_gpu_layers`.
 - **Python**: 3.10+
 - **Audio**: system microphone permissions enabled. `ffmpeg` accessible on PATH.
 
-
 ---
-
 
 ## 🔐 Privacy / Security (MVP)
 - Offline by default; no PHI egress.
 - Local SQLite cache (72h window) and JSONL logs under `data/`.
-- (Planned) Auto‑lock on idle; signed builds; SBOM.
-
+- (Planned) Auto-lock on idle; signed builds; SBOM.
 
 ---
 
-
 ## 📦 Setup
-1. **Clone & venv**
-```bash
-py -3.10 -m venv .venv
-.venv\Scripts\activate
-pip install -r requirements.txt
+1. **Clone & create a virtual environment**
+   ```bash
+   git clone https://github.com/minuteone/m1.git
+   cd m1
+   py -3.10 -m venv .venv
+   .venv\Scripts\activate
+   pip install -r requirements.txt
+   ```
+
+   _macOS/Linux_
+   ```bash
+   python3.10 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Download runtime models**
+   - Place the quantized **faster-whisper small-int8** model under `models/asr/` (or update `config.yaml`).
+   - Place the **Llama-3.2-3B-Instruct Q4_K_S** GGUF file under `models/`.
+
+3. **Configure the app**
+   - Edit `config.yaml` to point at your local model paths and data directories.
+   - Adjust ASR, LLM, pathway, and privacy settings to match the deployment target.
+
+4. **Launch the backend**
+   ```bash
+   uvicorn m1.api.main:app --reload --host 127.0.0.1 --port 8000
+   ```
+   - Exposes local FastAPI endpoints (`/asr/segment`, `/extract/visit`, etc.).
+
+5. **Launch the side-panel UI**
+   ```bash
+   python -m m1.ui.app --config config.yaml
+   ```
+   - Opens the PyQt panel with tabs (**Note | Handoff | Discharge | Sources**) and the chips rail.
+
+6. **(Optional) Run smoketests**
+   ```bash
+   pytest
+   ```
+   - Validates regex extractors, schema guards, and composer templates once implemented.
+
+---
+
+## 🛠 Development Notes
+- **Data folders**: `data/` contains the SQLite cache and log output; ensure disk encryption.
+- **Templates & plan packs**: stored under `templates/` and `planpacks/`; version via git tagging.
+- **Model paths**: configurable per site; ship via offline installers.
+
+---
+
+## 📄 Licensing & Compliance
+- Ship with HIPAA/GDPR-ready documentation (BAA/DPA templates).
+- Provide SBOM, signed binaries, and vulnerability disclosure policy.
+
+```

--- a/config.yaml
+++ b/config.yaml
@@ -2,9 +2,9 @@ asr: {model: faster-whisper-small-int8, vad: silero, segment_ms: 20000}
 llm: {path: models/llama-3.2-3b-instruct-q4_ks.gguf, threads: 8, ctx: 2048, n_gpu_layers: 8, temperature: 0.2}
 cache: {window_hours: 72, db: data/chart.sqlite}
 confidence:
-weights: {rule_hit:0.35, p_llm:0.25, asr:0.15, ontology:0.10, context:0.15}
-thresholds: {auto_accept:0.90, soft_confirm:0.70, must_confirm:0.45}
-risk_bumps: {high:0.05, medium:0.03}
+  weights: {rule_hit:0.35, p_llm:0.25, asr:0.15, ontology:0.10, context:0.15}
+  thresholds: {auto_accept:0.90, soft_confirm:0.70, must_confirm:0.45}
+  risk_bumps: {high:0.05, medium:0.03}
 localization: {discharge_languages: ["en","es"], default: "en"}
 pathways: {enabled: ["chest_pain","seizure","sepsis"]}
 privacy: {offline_only: true, log_retention_days: 30, auto_lock_idle_min: 5}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic==2.6.4
+pydantic-settings==2.2.1
+jinja2==3.1.3
+sqlalchemy==2.0.29
+aiofiles==23.2.1
+aiosqlite==0.19.0
+python-dotenv==1.0.1
+faster-whisper==1.0.0
+llama-cpp-python==0.2.62
+PyQt6==6.6.1
+sounddevice==0.4.6
+rich==13.7.1
+httpx==0.27.0
+pyyaml==6.0.1


### PR DESCRIPTION
## Summary
- fix indentation for the confidence configuration block so nested weights and thresholds load correctly
- refresh the README setup instructions with complete virtualenv, launch, and testing guidance
- add a requirements.txt capturing the baseline runtime dependencies for the MVP stack

## Testing
- `python - <<'PY'
import yaml, pathlib
path = pathlib.Path('config.yaml')
with path.open() as fh:
    data = yaml.safe_load(fh)
print('Loaded confidence keys:', sorted(data['confidence'].keys()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68cfd765f4548328aa92223ba20fd665